### PR TITLE
Header menu mobile fix

### DIFF
--- a/demo/Data-JSON.htm
+++ b/demo/Data-JSON.htm
@@ -69,7 +69,7 @@
 					calDataSource: 
 					[
 					    {
-					        sourceFetchType: "DATERANGE",
+					        sourceFetchType: "ALL",
 					        sourceType: "JSON",						
 					        source: {
 
@@ -85,7 +85,7 @@
 						              "description": "", 
 						              "url": "", 
 
-						              "icon": "icon-Meeting", 
+						              "icon": "cs-icon-Meeting", 
 						              "color": "20DAEC", 
 						              "borderColor": "000000", 
 						              "textColor": "000000",

--- a/src/calenstyle.css
+++ b/src/calenstyle.css
@@ -410,9 +410,6 @@
 
 .cContHeaderSections
 {
-	height: 45px;
-	line-height: 45px;
-
 	text-align: center;
 	vertical-align: top;
 }
@@ -564,6 +561,7 @@
 .cContHeaderMenuSections
 {
 	display: inline-block;
+	padding-bottom:10px;
 }
 
 .cContHeaderMenuSections li

--- a/src/calenstyle.css
+++ b/src/calenstyle.css
@@ -59,7 +59,7 @@
 	left: 0;
 	background: #FFFFFF;
 
-	overflow: auto;
+	overflow: visible;
 
 	-webkit-overflow-scrolling: touch;
 

--- a/src/calenstyle.js
+++ b/src/calenstyle.js
@@ -2469,9 +2469,9 @@ CalenStyle.prototype = {
 		iCalendarContHeight = $occCalendarContInner.outerHeight();
 	
 		if(iCalendarContWidth > 410 || iCalendarContHeight > 410)
-			$(to.elem).find(".cContHeader, .cContHeaderSections, .cContHeaderDatePickerIcon, .cContHeaderFullscreen, .cContHeaderNavButton").css({"height": 45, "line-height": 45+"px"});
+			$(to.elem).find(".cContHeader, .cContHeaderDatePickerIcon, .cContHeaderFullscreen, .cContHeaderNavButton").css({"height": 45, "line-height": 45+"px"});
 		else
-			$(to.elem).find(".cContHeader, .cContHeaderSections, .cContHeaderDatePickerIcon, .cContHeaderFullscreen, .cContHeaderNavButton").css({"height": 45, "line-height": 45+"px"});
+			$(to.elem).find(".cContHeader, .cContHeaderDatePickerIcon, .cContHeaderFullscreen, .cContHeaderNavButton").css({"height": 45, "line-height": 45+"px"});
 	},
 
 	//--------------------------------- Header Related Functions End ---------------------------------


### PR DESCRIPTION
The buttons month/week/day/agenda could split up to two lines on mobile view. Especially when using another language with longer texts. By changing a few CSS classes and removing a CSS class from a line in the calenstyle.js file, now the header will expand like it should and not overflow the events or dates.
